### PR TITLE
fix: Make scripts work on Windows

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,6 +2,8 @@
 
 To get started developing Reptar locally:
 
+## OSX / Linux
+
 ```shell
 git clone git@github.com:reptar/reptar.git
 cd reptar
@@ -10,15 +12,38 @@ npm install
 
 From there you're good to go!
 
-Easiest way to add/modify/test features is by writing a test and then interacting with Reptar through there.
+## Windows
 
+First of all, if you're using Git Bash to clone the repo, then make sure that you enter this command into the terminal:  
+```shell
+git config --global core.autocrlf false
+```
+It will ensure that all file line endings are in the LF format when cloning the repo, not the standard CRLF format that Windows uses. This is to comply with Reptar's ESLint rules.  
+
+Secondly, you might need to install some Windows build tools to make the node-gyp dependency work. This can be easily done by typing in the following into your terminal:  
+```shell
+npm install --global --production windows-build-tools
+```  
+(For more information visit [this page](https://github.com/nodejs/node-gyp#installation))  
+If Reptar still give you errors about node-gyp after trying to install it you might need to download Python version 2 manually. During installation you need to set the PATH environment variable by clicking on a checkbox.
+
+Finally move on to running the following commands to download Reptar and install its dependencies:  
+
+```shell
+git clone git@github.com:reptar/reptar.git
+cd reptar
+npm install
+```
+
+## Testing
+The easiest way to add/modify/test features is by writing a test and then interacting with Reptar through there.
 You can start mocha in watch mode and then begin coding:
 
 ```shell
 npm run test:unit -- --watch
 ```
 
-# Commit Messages
+## Commit Messages
 
 Reptar is using [standard-version](https://github.com/conventional-changelog/standard-version) to standardize its commit messages. For a quick overview of what that looks like [consult the quick start guide](https://github.com/conventional-changelog/standard-version#commit-message-convention-at-a-glance) or look at previous commits.
 
@@ -26,6 +51,6 @@ By default a git-hook is installed to validate your commit message.
 
 Additionally you should use [commitizen](https://github.com/commitizen/cz-cli) to automate and streamline the process of creating properly formatted commit messages.
 
-# Cutting a release
+## Cutting a release
 
 When ready to cut a release just run `npm run release`. We're closely following the [instructions on the standard-version documentation page](https://github.com/conventional-changelog/standard-version#cut-a-release).

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "docs": "./node_modules/.bin/esdoc -c esdoc.json",
     "gh-pages": "npm run docs && gdd --branch gh-pages --src esdocs --remote origin",
-    "compile": "babel lib --out-dir dist/lib && babel bin --out-dir dist/bin && cp lib/config/config_example.yml dist/lib/config/config_example.yml",
-    "prepublish": "NODE_ENV=production npm run compile",
+    "compile": "babel lib --out-dir dist/lib && babel bin --out-dir dist/bin && shx cp lib/config/config_example.yml dist/lib/config/config_example.yml",
+    "prepublish": "cross-env NODE_ENV=production npm run compile",
     "postpublish": "npm run gh-pages",
     "pretest": "npm run lint",
     "test": "mocha --recursive --require ./test/setup.js --reporter spec",
@@ -119,6 +119,7 @@
     "babel-plugin-transform-regenerator": "^6.20.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "coveralls": "^2.11.15",
+    "cross-env": "^3.1.3",
     "esdoc": "^0.4.8",
     "esdoc-es7-plugin": "0.0.3",
     "eslint": "^3.12.2",
@@ -130,6 +131,7 @@
     "nyc": "^10.0.0",
     "power-assert": "^1.4.2",
     "rewire": "^2.5.2",
+    "shx": "^0.2.1",
     "sinon": "^2.0.0-pre.3",
     "standard-version": "^4.0.0",
     "validate-commit-msg": "^2.8.2"


### PR DESCRIPTION
This pull request hopefully solves issue #65 .

I've added 2 dependencies to make it possible to install Reptar on Windows. These dependencies are to make sure that NODE_ENV and OS commands are cross platform compatible.  

Dependencies:  
- "cross-env": "^3.1.3"
- "shx": "^0.2.1"

I've also written down some instructions in the DEVELOPMENT.md file for Windows users. Just to save them some time when troubleshooting.