### PR TITLE
fix: Make serve work on Windows

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -29,7 +29,7 @@ export default async function serve() {
 
   server.route({
     method: 'GET',
-    path: path.join('/', config.get('server.baseurl'), '/{param*}'),
+    path: path.posix.join('/', config.get('server.baseurl'), '/{param*}'),
     handler: {
       directory: {
         path: '.',


### PR DESCRIPTION
Adding `posix` makes the path use forward slashes on Windows as well, instead of backslash. 

This pull request references issue #61 