### PR TITLE
fix: Calculate correct destination path for files without a file extension

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -200,6 +200,10 @@ export default class File {
    */
   _calculateDestination() {
     let destinationUrl;
+    const hasMarkdownExtension = Url.pathHasMarkdownExtension(
+      this.path,
+      this._config.get('markdown.extensions')
+    );
 
     /**
      * If the file itself wants to customize what its URL is then it will use
@@ -221,25 +225,29 @@ export default class File {
       destinationUrl = Url.interpolatePermalink(this.data.permalink, this.data);
     } else {
       // Path to file relative to root of project.
-      const pathRelative = this.path.replace(
-        this._config.get('path.source'),
-        ''
-      );
+      destinationUrl = this.path.replace(this._config.get('path.source'), '');
 
-      // If the file has no URL set and no permalink then use its relative file
-      // path as its url.
-      destinationUrl = Url.replaceMarkdownExtension(
-        pathRelative,
-        this._config.get('markdown.extensions')
-      );
+      if (hasMarkdownExtension) {
+        // If the file has no URL set and no permalink then use its relative
+        // file path as its url.
+        destinationUrl = Url.replaceMarkdownExtension(
+          destinationUrl,
+          this._config.get('markdown.extensions')
+        );
+      }
     }
 
     if (this.assetProcessor) {
       destinationUrl = this.assetProcessor.calculateDestination(destinationUrl);
     }
 
-    this.destination = Url.makeUrlFileSystemSafe(destinationUrl);
-    this.data.url = Url.makePretty(this.destination);
+    if (hasMarkdownExtension) {
+      this.destination = Url.makeUrlFileSystemSafe(destinationUrl);
+      this.data.url = Url.makePretty(this.destination);
+    } else {
+      this.destination = destinationUrl;
+      this.data.url = destinationUrl;
+    }
   }
 
   /**

--- a/lib/url.js
+++ b/lib/url.js
@@ -11,6 +11,18 @@ const isDistBuild = __dirname.indexOf('dist') > -1;
 // Cached slug options.
 let slugOptions;
 
+/**
+ * @param {string} filePath A file path.
+ * @param {Array.<string>} markdownExtensions Array of known markdown file
+ *   extensions.
+ * @return {number} Index of the filepath extension.
+ */
+function getMarkdownExtensionIndexForFilePath(filePath, markdownExtensions) {
+  // Get file extension of file. i.e. 'post.md' would give 'md'.
+  const fileExtension = path.extname(filePath).replace(/^\./, '');
+  return markdownExtensions.indexOf(fileExtension);
+}
+
 const Url = {
   /**
    * Interpolates variables into a permalink structure.
@@ -88,6 +100,20 @@ const Url = {
   },
 
   /**
+   * Check if given filePath matches a markdown extension.
+   * @param {string} filePath A file path.
+   * @param {Array.<string>} markdownExtensions Array of known markdown file
+   *   extensions.
+   * @return {boolean} Whether this filePath matches any of our known markdown
+   *   extensions.
+   */
+  pathHasMarkdownExtension(filePath, markdownExtensions) {
+    return (
+      getMarkdownExtensionIndexForFilePath(filePath, markdownExtensions) > -1
+    );
+  },
+
+  /**
    * Replaces a markdown file path with `.html` if it's a known markdown file.
    * @param {string} filePath A file path.
    * @param {Array.<string>} markdownExtensions Array of known markdown file
@@ -95,9 +121,10 @@ const Url = {
    * @return {string} Modified file path.
    */
   replaceMarkdownExtension(filePath, markdownExtensions) {
-    // Get file extension of file. i.e. 'post.md' would give 'md'.
-    const fileExtension = path.extname(filePath).replace(/^\./, '');
-    const index = markdownExtensions.indexOf(fileExtension);
+    const index = getMarkdownExtensionIndexForFilePath(
+      filePath,
+      markdownExtensions
+    );
 
     let result = filePath;
 

--- a/test/e2e/api.spec.js
+++ b/test/e2e/api.spec.js
@@ -93,7 +93,7 @@ describe('api', function test() {
       });
 
       commonAssertions({
-        expectedLength: 14,
+        expectedLength: 15,
       });
     });
 
@@ -129,7 +129,7 @@ describe('api', function test() {
       });
 
       commonAssertions({
-        expectedLength: 13,
+        expectedLength: 14,
       });
 
       it('every item is not filtered', () => {
@@ -149,7 +149,7 @@ describe('api', function test() {
       });
 
       commonAssertions({
-        expectedLength: 6,
+        expectedLength: 7,
       });
 
       it('every item is skipProcessing', () => {
@@ -209,7 +209,7 @@ describe('api', function test() {
       });
 
       commonAssertions({
-        expectedLength: 9,
+        expectedLength: 10,
       });
 
       it('every item is assetProcessor', () => {

--- a/test/fixtures/simple-site/expected/CNAME
+++ b/test/fixtures/simple-site/expected/CNAME
@@ -1,0 +1,1 @@
+fixturesite.com

--- a/test/fixtures/simple-site/src/CNAME
+++ b/test/fixtures/simple-site/src/CNAME
@@ -1,0 +1,1 @@
+fixturesite.com

--- a/test/unit/url.spec.js
+++ b/test/unit/url.spec.js
@@ -65,6 +65,44 @@ describe('url Url', () => {
     });
   });
 
+  describe('pathHasMarkdownExtension', () => {
+    it('matches known extensions', () => {
+      const markdownExtensions = ['md', 'markdown'];
+
+      assert.equal(
+        Url.pathHasMarkdownExtension(
+          '/_posts/hello-world.md',
+          markdownExtensions
+        ),
+        true
+      );
+
+      assert.equal(
+        Url.pathHasMarkdownExtension(
+          '/_posts/hello-world.markdown',
+          markdownExtensions
+        ),
+        true
+      );
+
+      assert.equal(
+        Url.pathHasMarkdownExtension(
+          '/_posts/hello-world.mkdown',
+          markdownExtensions
+        ),
+        false
+      );
+
+      assert.equal(
+        Url.pathHasMarkdownExtension(
+          '/_posts/hello-world.html',
+          markdownExtensions
+        ),
+        false
+      );
+    });
+  });
+
   describe('replaceMarkdownExtension', () => {
     it('replaces known markdown extensions', () => {
       const markdownExtensions = ['md', 'markdown'];
@@ -157,6 +195,9 @@ describe('url Url', () => {
       assert.equal(Url.makePretty(url), url);
 
       url = '/images/index.gif';
+      assert.equal(Url.makePretty(url), url);
+
+      url = '/CNAME';
       assert.equal(Url.makePretty(url), url);
     });
   });


### PR DESCRIPTION
For example if you have a file `CNAME` and you just want it copied over this fixes that.